### PR TITLE
Error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ __pycache__
 # Ignore for now
 .github/workflows/doc_build.yml
 config
+.github/workflows/docs.yml

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -142,7 +142,6 @@ private:
     
     void get_stream_state();
     
-    void save_frame_pgm(ArvBuffer *buffer);
     void save_genicam_xml(std::string filepath);
 
 

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -157,6 +157,8 @@ private:
     void auto_stop_stream();
 
     void set_frame_count(unsigned int frame_count, OdinData::IpcMessage& reply);
+    void set_empty_buffers(int n_empty_buffers, OdinData::IpcMessage& reply);
+
 
     void acquire_n_buffer(unsigned int n_buffers, OdinData::IpcMessage& reply);
     void acquire_buffer();
@@ -214,8 +216,7 @@ private:
     size_t payload_ {};                                 ///< frame size in bytes
 
     unsigned int frame_count_ {DEFAULT_FRAME_COUNT};    ///< current frame count in MultiFrame mode
-    unsigned int min_frame_count_;                      ///< current frame count in MultiFrame mode
-    unsigned int max_frame_count_;                      ///< current frame count in MultiFrame mode
+
 
 
     /**********************************
@@ -233,7 +234,7 @@ private:
 
     long long n_frames_made_ {0};                       ///< Number of frames created from buffers
 
-    int n_empty_buffers_{DEFAULT_EMPTY_BUFF};           ///< number of empty buffers to initialise the current stream with. Defaults to 50
+    int n_empty_buffers_ {DEFAULT_EMPTY_BUFF};           ///< number of empty buffers to initialise the current stream with. Defaults to 50
     int n_input_buff_ {0};                              ///< n of input buffers in the current stream
     int n_output_buff_ {0};                             ///< n of output buffers in the current stream
     long unsigned int n_completed_buff_ {0};            ///< n of successful buffers

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -108,6 +108,7 @@ private:
     **       Plugin Functions       **
     **********************************/
 
+    void log_error(std::string msg);
     void get_config(int32_t get_option);
 
     /*********************************

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -104,7 +104,6 @@ private:
 
     void set_acquisition_mode(std::string acq_mode);
     void get_acquisition_mode();
-    void set_aravis_callback(bool arv_callback);
 
     void set_exposure(double exposure_time_us);
     void get_exposure_bounds();

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -8,6 +8,11 @@
 #ifndef FRAMEPROCESSOR_ARAVISDETECTORPLUGIN_H_
 #define FRAMEPROCESSOR_ARAVISDETECTORPLUGIN_H_
 
+#define GET_CONFIG_CAMERA_INIT 1
+#define GET_CONFIG_CAMERA_PARAMS 2
+#define GET_CONFIG_STREAM_STAT 3
+#define GET_CONFIG_ALL 4
+
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
 
@@ -57,7 +62,7 @@ public:
     static const double      DEFAULT_EXPOSURE_TIME; ///< Exposure time in microseconds
     static const double      DEFAULT_FRAME_RATE;    ///< Frame rate in hertz
     static const double      DEFAULT_FRAME_COUNT;   ///< Frame count
-    static const bool        DEFAULT_CALLBACK;  ///< default callback value
+    static const bool        DEFAULT_CALLBACK;      ///< default callback value
 
     /** Flags*/
     static const std::string START_STREAM;          ///< starts continuos mode acquisition   
@@ -75,6 +80,7 @@ public:
     static const std::string CONFIG_ACQUISITION_MODE;///< set the camera acquisition mode: "Continuous", "SingleFrame","MultiFrame"
     static const std::string CONFIG_CALLBACK;       ///< Choose weather to activate the Aravis callback mechanism for frame acquisition
     static const std::string CONFIG_QUERY_FREQ;     ///< miliseconds between querying the camera for config
+    static const std::string CONFIG_STATUS_FREQ;    ///< set the status polling frequency in miliseconds
 
     /** Names and settings */
     static const std::string DATA_SET_NAME;
@@ -89,7 +95,6 @@ private:
     **       Plugin Functions       **
     **********************************/
 
-    void read_config(int32_t display_option);
     void get_config(int32_t get_option);
 
     /*********************************
@@ -155,7 +160,7 @@ private:
     bool camera_connected_;                 ///< is the camera connected?
     
     size_t delay_ms_ {1000};                ///< delay between config queries in milliseconds  
-    std::string temp_file_path_{};           ///< 
+    std::string temp_file_path_{};          ///< temporary file path for  
 
 
     /*********************************

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -153,7 +153,6 @@ private:
     boost::thread *thread_;                 ///< Pointer to status thread
     bool working_;                          ///< Is the status thread working?
     bool streaming_;                        ///< Is the camera streaming data?
-    bool aravis_callback_;                  ///< Is the camera emitting signals when a buffer is finished?
     bool camera_connected_;                 ///< is the camera connected?
     
     size_t delay_ms_ {1000};                ///< delay between config queries in milliseconds  

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -88,7 +88,6 @@ public:
     static const std::string CONFIG_PIXEL_FORMAT;   ///< set pixel encoding Mono8/ 12bit/ etc
     static const std::string CONFIG_ACQUISITION_MODE;///< set the camera acquisition mode: "Continuous", "SingleFrame","MultiFrame"
     static const std::string CONFIG_CALLBACK;       ///< Choose weather to activate the Aravis callback mechanism for frame acquisition
-    static const std::string CONFIG_QUERY_FREQ;     ///< miliseconds between querying the camera for config
     static const std::string CONFIG_STATUS_FREQ;    ///< set the status polling frequency in miliseconds
     static const std::string CONFIG_EMPTY_BUFF;     ///< number of empty buffers in a stream object 
     static const std::string CONFIG_CAMERA_ID;      ///< camera's manufacturer id
@@ -172,7 +171,7 @@ private:
     bool streaming_;                                    ///< Is the camera streaming data?
     bool camera_connected_;                             ///< is the camera connected?
     
-    size_t delay_ms_ {DEFAULT_STATUS_FREQ};             ///< delay between config queries in milliseconds  
+    size_t status_freq_ms {DEFAULT_STATUS_FREQ};        ///< delay between config queries in milliseconds  
     std::string temp_file_path_{DEFAULT_FILE_PATH};     ///< temporary file path for  
 
 

--- a/cpp/AravisPlugin/include/AravisDetectorPlugin.h
+++ b/cpp/AravisPlugin/include/AravisDetectorPlugin.h
@@ -17,6 +17,7 @@
 #include <boost/thread.hpp>
 
 #include <map>
+#include <sys/stat.h>
 #include <log4cxx/logger.h>
 #include <log4cxx/basicconfigurator.h>
 #include <log4cxx/propertyconfigurator.h>
@@ -107,35 +108,41 @@ private:
     **       Plugin Functions       **
     **********************************/
 
+    void log_error(std::string msg, OdinData::IpcMessage& reply);
     void log_error(std::string msg);
+    void log_warning(std::string msg, OdinData::IpcMessage& reply);
+    void log_warning(std::string msg);
+
     void get_config(int32_t get_option);
 
+    void set_file_name(std::string file_id,  OdinData::IpcMessage& reply);
+    void set_file_path(std::string new_file_path, OdinData::IpcMessage& reply);
+    void set_dataset_name(std::string data_set_name,  OdinData::IpcMessage& reply);
+    void set_compression_type(std::string compression_type,  OdinData::IpcMessage& reply);
+    void set_status_poll_frequency(size_t new_frequency,  OdinData::IpcMessage& reply);
+    
     /*********************************
     **       Camera Functions       **
     **********************************/
 
-    void connect_aravis_camera(std::string ip); 
+    void connect_aravis_camera(std::string ip, OdinData::IpcMessage& reply); 
     void check_connection();
-    void find_aravis_cameras();
+    void find_aravis_cameras(OdinData::IpcMessage& reply);
     void get_camera_serial();
     void get_camera_id();
 
-    void set_acquisition_mode(std::string acq_mode);
+    void set_acquisition_mode(std::string acq_mode, OdinData::IpcMessage& reply);
     void get_acquisition_mode();
 
-    void set_exposure(double exposure_time_us);
+    void set_exposure(double exposure_time_us, OdinData::IpcMessage& reply);
     void get_exposure_bounds();
     void get_exposure();
 
-    void set_frame_rate(double frame_rate_hz);
+    void set_frame_rate(double frame_rate_hz, OdinData::IpcMessage& reply);
     void get_frame_rate_bounds();
     void get_frame_rate();
 
-    void set_frame_count(double frame_count);
-    void get_frame_count_bounds();
-    void get_frame_count();
-
-    void set_pixel_format(std::string pixel_format);
+    void set_pixel_format(std::string pixel_format,OdinData::IpcMessage& reply);
     void get_available_pixel_formats();
     void get_pixel_format();
 
@@ -145,10 +152,13 @@ private:
     **    Stream/buffer functions    **
     ***********************************/
 
-    void start_stream();
-    void stop_stream();
+    void start_stream(OdinData::IpcMessage& reply);
+    void stop_stream(OdinData::IpcMessage& reply);
+    void auto_stop_stream();
 
-    void acquire_n_buffer(unsigned int n_buffers);
+    void set_frame_count(unsigned int frame_count, OdinData::IpcMessage& reply);
+
+    void acquire_n_buffer(unsigned int n_buffers, OdinData::IpcMessage& reply);
     void acquire_buffer();
     bool buffer_is_valid(ArvBuffer *buffer);
     void process_buffer(ArvBuffer *buffer);
@@ -171,7 +181,7 @@ private:
     bool streaming_;                                    ///< Is the camera streaming data?
     bool camera_connected_;                             ///< is the camera connected?
     
-    size_t status_freq_ms {DEFAULT_STATUS_FREQ};        ///< delay between config queries in milliseconds  
+    size_t status_freq_ms_ {DEFAULT_STATUS_FREQ};        ///< delay between config queries in milliseconds  
     std::string temp_file_path_{DEFAULT_FILE_PATH};     ///< temporary file path for  
 
 

--- a/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
+++ b/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
@@ -1188,10 +1188,8 @@ DataType AravisDetectorPlugin::pixel_format_to_datatype(std::string pixel_form){
   if(pixel_form == "Mono8")
     return DataType::raw_8bit;
   if(pixel_form == "Mono12")
-    log_error("Pixel type unsupported, return raw_unkown");
+    log_error("Pixel type unsupported, return unkown");
   if(pixel_form == "RGB8")
-    return DataType::raw_8bit;
-  if(pixel_form == "Mono8")
     return DataType::raw_8bit;
   
 

--- a/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
+++ b/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
@@ -72,7 +72,7 @@ namespace FrameProcessor
   const std::string AravisDetectorPlugin::COMPRESSION_TYPE    = "compression";
   const std::string AravisDetectorPlugin::TEMP_FILES_PATH     = "file_path";
 
-/** @brief Construct for the plugin
+/** @brief Constructor for the plugin
  * 
  * Sets default values, starts the status monitoring thread and logger object
  * Then it logs "AravisDetectorPlugin loaded"
@@ -80,7 +80,6 @@ namespace FrameProcessor
 AravisDetectorPlugin::AravisDetectorPlugin() :
   working_(true),
   streaming_(false),
-  aravis_callback_(true),
   camera_connected_(false),
   frame_count_(0)
 {
@@ -172,7 +171,6 @@ void AravisDetectorPlugin::requestConfiguration(OdinData::IpcMessage& reply){
     reply.set_param(get_name() + "/" + AravisDetectorPlugin::CONFIG_FRAME_COUNT, frame_count_);
     reply.set_param(get_name() + "/" + AravisDetectorPlugin::CONFIG_PIXEL_FORMAT, pixel_format_);
     reply.set_param(get_name() + "/" + AravisDetectorPlugin::CONFIG_ACQUISITION_MODE, acquisition_mode_);
-    reply.set_param(get_name() + "/" + AravisDetectorPlugin::CONFIG_CALLBACK, aravis_callback_);
 
 }
 
@@ -604,17 +602,6 @@ void AravisDetectorPlugin::get_acquisition_mode(){
   acquisition_mode_ = arv_acquisition_mode_to_string(temp);
 }
 
-void AravisDetectorPlugin::set_aravis_callback(bool arv_callback){
-  aravis_callback_=arv_callback;
-
-  // if there is no active stream, just exit
-  if(stream_ == NULL) return;
-
-
-  // some code to handle changing this mode during runs. 
-}
-
-
 /** @brief Set exposure time in microseconds
  * 
  * On success prints:
@@ -955,10 +942,8 @@ void AravisDetectorPlugin::start_stream(){
   }
 
   // stream callback mechanism
-  if(aravis_callback_){
-    arv_stream_set_emit_signals (stream_, TRUE);
-    g_signal_connect (stream_, "new-buffer", G_CALLBACK (buffer_callback), this);
-  }
+  arv_stream_set_emit_signals (stream_, TRUE);
+  g_signal_connect (stream_, "new-buffer", G_CALLBACK (buffer_callback), this);
 
   // Start the stream
   streaming_= true;
@@ -978,9 +963,8 @@ void AravisDetectorPlugin::stop_stream(){
     return;
   }
 
-  if(aravis_callback_){
-    arv_stream_set_emit_signals (stream_, FALSE);
-  }
+  arv_stream_set_emit_signals (stream_, FALSE);
+
 
   arv_camera_stop_acquisition (camera_, error.get());
   streaming_ = false;

--- a/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
+++ b/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
@@ -42,7 +42,7 @@ struct GErrorWrapper {
 
 namespace FrameProcessor
 {
-  /** Default configurations */
+  /** Default config values*/
   const std::string AravisDetectorPlugin::DEFAULT_CAMERA_IP     = "127.0.0.1";
   const std::string AravisDetectorPlugin::DEFAULT_CAMERA_ID     = "";
   const std::string AravisDetectorPlugin::DEFAULT_CAMERA_SERIAL = "";
@@ -60,18 +60,21 @@ namespace FrameProcessor
   const std::string AravisDetectorPlugin::DEFAULT_DATASET       = "data";
   const std::string AravisDetectorPlugin::DEFAULT_FILE_NAME     = "test";
   
+  /** Config names */
+
   /** Flags*/
   const std::string AravisDetectorPlugin::START_STREAM        = "start";
   const std::string AravisDetectorPlugin::STOP_STREAM         = "stop";
   const std::string AravisDetectorPlugin::LIST_DEVICES        = "list_devices";
   const std::string AravisDetectorPlugin::ACQUIRE_BUFFER      = "frames";
 
-  /** Config names*/
+  /** Camera name*/
   const std::string AravisDetectorPlugin::CONFIG_CAMERA_IP    = "ip_address";
   const std::string AravisDetectorPlugin::CONFIG_CAMERA_ID    = "camera_id";
   const std::string AravisDetectorPlugin::CONFIG_CAMERA_SERIAL= "camera_serial_number";
   const std::string AravisDetectorPlugin::CONFIG_CAMERA_MODEL = "camera_model";
-
+  
+  /** Camera config*/
   const std::string AravisDetectorPlugin::CONFIG_EXPOSURE     = "exposure_time";
   const std::string AravisDetectorPlugin::CONFIG_FRAME_RATE   = "frame_rate";
   const std::string AravisDetectorPlugin::CONFIG_FRAME_COUNT  = "frame_count";
@@ -80,7 +83,7 @@ namespace FrameProcessor
   const std::string AravisDetectorPlugin::CONFIG_STATUS_FREQ  = "status_frequency_ms";
   const std::string AravisDetectorPlugin::CONFIG_EMPTY_BUFF   = "empty_buffers";
 
-  /** Names and settings */
+  /** Frame creation*/
   const std::string AravisDetectorPlugin::TEMP_FILES_PATH     = "file_path";
   const std::string AravisDetectorPlugin::DATA_SET_NAME       = "data_set_name";
   const std::string AravisDetectorPlugin::FILE_NAME           = "file_name"; 
@@ -128,47 +131,64 @@ void AravisDetectorPlugin::process_frame(boost::shared_ptr<Frame> frame)
  * @param[in] config - IpcMessage containing configuration data
  * @param[out] reply - Response IpcMessage
  */
-void AravisDetectorPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply){
-  try{
-    /** List all devices*/
-    if (config.has_param(START_STREAM)){
-      start_stream(reply);}
-    if (config.has_param(STOP_STREAM)){
-      stop_stream(reply);}
-    if (config.has_param(LIST_DEVICES)){
-      find_aravis_cameras(reply);}
-    if (config.has_param(ACQUIRE_BUFFER)){
-      acquire_n_buffer(config.get_param<int>(ACQUIRE_BUFFER), reply);}
-    if (config.has_param(CONFIG_CAMERA_IP)){
-      connect_aravis_camera(config.get_param<std::string>(CONFIG_CAMERA_IP), reply);}
-    if (config.has_param(TEMP_FILES_PATH)){
-      set_file_path(config.get_param<std::string>(TEMP_FILES_PATH), reply);}
-    if (config.has_param(CONFIG_STATUS_FREQ)){
-      set_status_poll_frequency(static_cast<size_t>(config.get_param<int>(CONFIG_STATUS_FREQ)), reply);}
-    if (config.has_param(CONFIG_EXPOSURE)){
-      set_exposure(config.get_param<double>(CONFIG_EXPOSURE), reply);
-    }
-    if (config.has_param(CONFIG_FRAME_RATE)){
-      set_frame_rate(config.get_param<double>(CONFIG_FRAME_RATE), reply);
-    }
-    if (config.has_param(CONFIG_FRAME_COUNT)){
-      set_frame_count(config.get_param<int32_t>(CONFIG_FRAME_COUNT), reply);
-    }
-    if (config.has_param(CONFIG_PIXEL_FORMAT)){
-      set_pixel_format(config.get_param<std::string>(CONFIG_PIXEL_FORMAT), reply);
-    }
-    if (config.has_param(CONFIG_ACQUISITION_MODE)){
-      set_acquisition_mode(config.get_param<std::string>(CONFIG_ACQUISITION_MODE), reply);
-    }
-    if (config.has_param(DATA_SET_NAME)){
-      set_dataset_name(config.get_param<std::string>(DATA_SET_NAME), reply);
-    }
-    if (config.has_param(FILE_NAME)){
-      set_file_name(config.get_param<std::string>(FILE_NAME), reply);
-    }   
-    if (config.has_param(COMPRESSION_TYPE)){
-      set_compression_type(config.get_param<std::string>(COMPRESSION_TYPE), reply);
-    }
+void AravisDetectorPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply)
+{  try{
+    /** Flags*/
+    if (config.has_param(START_STREAM))
+{      start_stream(reply);
+}
+    if (config.has_param(STOP_STREAM))
+{      stop_stream(reply);
+}
+    if (config.has_param(LIST_DEVICES))
+{      find_aravis_cameras(reply);
+}    
+    if (config.has_param(ACQUIRE_BUFFER))
+{      acquire_n_buffer(config.get_param<int>(ACQUIRE_BUFFER), reply);
+}
+    
+    /** Connect to camera*/
+    if (config.has_param(CONFIG_CAMERA_IP))
+{      connect_aravis_camera(config.get_param<std::string>(CONFIG_CAMERA_IP), reply);
+}
+
+    /** Camera config*/
+    if (config.has_param(CONFIG_EXPOSURE))
+{      set_exposure(config.get_param<double>(CONFIG_EXPOSURE), reply);
+}
+    if (config.has_param(CONFIG_FRAME_RATE))
+{      set_frame_rate(config.get_param<double>(CONFIG_FRAME_RATE), reply);
+}
+    if (config.has_param(CONFIG_FRAME_COUNT))
+{      set_frame_count(config.get_param<int32_t>(CONFIG_FRAME_COUNT), reply);
+}
+    if (config.has_param(CONFIG_PIXEL_FORMAT))
+{      set_pixel_format(config.get_param<std::string>(CONFIG_PIXEL_FORMAT), reply);
+}
+    if (config.has_param(CONFIG_ACQUISITION_MODE))
+{      set_acquisition_mode(config.get_param<std::string>(CONFIG_ACQUISITION_MODE), reply);
+}
+    if (config.has_param(CONFIG_STATUS_FREQ))
+{      set_status_poll_frequency(static_cast<size_t>(config.get_param<int>(CONFIG_STATUS_FREQ)), reply);
+}  
+    if (config.has_param(CONFIG_EMPTY_BUFF))
+{      set_empty_buffers(static_cast<size_t>(config.get_param<int>(CONFIG_EMPTY_BUFF)), reply);
+}  
+
+    /** Frame creation*/
+    if (config.has_param(TEMP_FILES_PATH))
+{      set_file_path(config.get_param<std::string>(TEMP_FILES_PATH), reply);
+}
+    if (config.has_param(DATA_SET_NAME))
+{      set_dataset_name(config.get_param<std::string>(DATA_SET_NAME), reply);
+}
+    if (config.has_param(FILE_NAME))
+{      set_file_name(config.get_param<std::string>(FILE_NAME), reply);
+}
+    if (config.has_param(COMPRESSION_TYPE))
+{      set_compression_type(config.get_param<std::string>(COMPRESSION_TYPE), reply);
+}
+
   }
   catch (std::runtime_error& e)
   {
@@ -1010,6 +1030,13 @@ void AravisDetectorPlugin::set_frame_count(unsigned int frame_count, OdinData::I
   LOG4CXX_INFO(logger_, "frame_count_ | old: "<< frame_count_ << " | new:" << frame_count);
   frame_count_ = frame_count;
 }
+/** @brief Sets maximum number of frames taken in stream mode
+ * @param n_empty_buffers unsigned int: frame limit
+ */
+void AravisDetectorPlugin::set_empty_buffers(int n_empty_buffers, OdinData::IpcMessage& reply){
+  LOG4CXX_INFO(logger_, "n_empty_buffers_ | old: "<< n_empty_buffers_ << " | new:" << n_empty_buffers);
+  n_empty_buffers_ = n_empty_buffers;
+}
 
 
 /** @brief processes a fixed number of buffers
@@ -1189,6 +1216,8 @@ DataType AravisDetectorPlugin::pixel_format_to_datatype(std::string pixel_form){
     return DataType::raw_8bit;
   if(pixel_form == "Mono12")
     log_error("Pixel type unsupported, return unkown");
+  if(pixel_form == "Mono16")
+    return DataType::raw_16bit;
   if(pixel_form == "RGB8")
     return DataType::raw_8bit;
   

--- a/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
+++ b/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
@@ -44,9 +44,9 @@ namespace FrameProcessor
 {
   /** Default configurations */
   const std::string AravisDetectorPlugin::DEFAULT_CAMERA_IP     = "127.0.0.1";
-  const std::string AravisDetectorPlugin::DEFAULT_CAMERA_ID     = "fake";
-  const std::string AravisDetectorPlugin::DEFAULT_CAMERA_SERIAL = "fake";
-  const std::string AravisDetectorPlugin::DEFAULT_CAMERA_MODEL  = "fake";
+  const std::string AravisDetectorPlugin::DEFAULT_CAMERA_ID     = "";
+  const std::string AravisDetectorPlugin::DEFAULT_CAMERA_SERIAL = "";
+  const std::string AravisDetectorPlugin::DEFAULT_CAMERA_MODEL  = "";
 
   const double      AravisDetectorPlugin::DEFAULT_EXPOSURE_TIME = 1000.0;
   const double      AravisDetectorPlugin::DEFAULT_FRAME_RATE    = 5;
@@ -193,7 +193,6 @@ void AravisDetectorPlugin::requestConfiguration(OdinData::IpcMessage& reply){
     reply.set_param(get_name() + "/" + AravisDetectorPlugin::TEMP_FILES_PATH, temp_file_path_);
     reply.set_param(get_name() + "/" + AravisDetectorPlugin::DATA_SET_NAME, data_set_name_);
     reply.set_param(get_name() + "/" + AravisDetectorPlugin::FILE_NAME, file_id_);
-    reply.set_param(get_name() + "/" + AravisDetectorPlugin::COMPRESSION_TYPE, compression_type_);
 
 }
 
@@ -417,11 +416,13 @@ void AravisDetectorPlugin::connect_aravis_camera(std::string ip_string){
   **      Camera init routine
   ****************************************/
 
+  LOG4CXX_INFO(logger_, "camera address old:"<< camera_address_ << " new:" << ip_string );
+
   camera_address_ = ip_string;
   camera_connected_ = true;
 
   // get config values 
-  get_config(1);
+  get_config(GET_CONFIG_CAMERA_INIT);
 
   save_genicam_xml(temp_file_path_);
 
@@ -483,7 +484,6 @@ void AravisDetectorPlugin::check_connection(){
   // if not, we need to stop all camera related processes before the code crashes
   if(streaming_)stop_stream();
   camera_ = NULL;
-
 }
 
 

--- a/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
+++ b/cpp/AravisPlugin/src/AravisDetectorPlugin.cpp
@@ -138,9 +138,6 @@ void AravisDetectorPlugin::configure(OdinData::IpcMessage& config, OdinData::Ipc
     if (config.has_param(CONFIG_ACQUISITION_MODE)){
       set_acquisition_mode(config.get_param<std::string>(CONFIG_ACQUISITION_MODE));
     }
-    if (config.has_param(CONFIG_CALLBACK)){
-      set_aravis_callback(config.get_param<bool>(CONFIG_CALLBACK));
-    }
     if (config.has_param(DATA_SET_NAME)){
       data_set_name_= config.get_param<std::string>(DATA_SET_NAME);
     }


### PR DESCRIPTION
Quite a few changes in total as I've been trying to implement all suggestions in the code review.

1. List_devices now saves the list in a map and sends the values in the status
2. Reply in configure is passed down to each function and set when an error occurs
3. Callback is always used now and there is no longer a configure option to toggle off
4. Status polling frequency is a config value, same with file path/data set name/ file name/ compression
5. removed read_config and save_frame_pgm
6. get config uses defined values in switch
7. errors are now using log_error functions and are propagated down the FP chain so they can be accessed by server.
8. Cleaned some functions.
9. Added more default values and configurable values were it made sense to try and remove any magic numbers
